### PR TITLE
style: info are now on the grid and centered

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,8 +36,8 @@
                             <svg class="svgaa" width="50px" height="50px" viewBox="0 0 20 20" version="1.1"
                                 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                                 <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-                                    <g class="svgconfuso" id="Dribbble-Light-Preview" transform="translate(-140.000000, -7559.000000)"
-                                        fill="#000000">
+                                    <g class="svgconfuso" id="Dribbble-Light-Preview"
+                                        transform="translate(-140.000000, -7559.000000)" fill="#000000">
                                         <g id="icons" transform="translate(56.000000, 160.000000)">
                                             <path
                                                 d="M94,7399 C99.523,7399 104,7403.59 104,7409.253 C104,7413.782 101.138,7417.624 97.167,7418.981 C96.66,7419.082 96.48,7418.762 96.48,7418.489 C96.48,7418.151 96.492,7417.047 96.492,7415.675 C96.492,7414.719 96.172,7414.095 95.813,7413.777 C98.04,7413.523 100.38,7412.656 100.38,7408.718 C100.38,7407.598 99.992,7406.684 99.35,7405.966 C99.454,7405.707 99.797,7404.664 99.252,7403.252 C99.252,7403.252 98.414,7402.977 96.505,7404.303 C95.706,7404.076 94.85,7403.962 94,7403.958 C93.15,7403.962 92.295,7404.076 91.497,7404.303 C89.586,7402.977 88.746,7403.252 88.746,7403.252 C88.203,7404.664 88.546,7405.707 88.649,7405.966 C88.01,7406.684 87.619,7407.598 87.619,7408.718 C87.619,7412.646 89.954,7413.526 92.175,7413.785 C91.889,7414.041 91.63,7414.493 91.54,7415.156 C90.97,7415.418 89.522,7415.871 88.63,7414.304 C88.63,7414.304 88.101,7413.319 87.097,7413.247 C87.097,7413.247 86.122,7413.234 87.029,7413.87 C87.029,7413.87 87.684,7414.185 88.139,7415.37 C88.139,7415.37 88.726,7417.2 91.508,7416.58 C91.513,7417.437 91.522,7418.245 91.522,7418.489 C91.522,7418.76 91.338,7419.077 90.839,7418.982 C86.865,7417.627 84,7413.783 84,7409.253 C84,7403.59 88.478,7399 94,7399">
@@ -65,69 +65,56 @@
 
                     <div class="content-main">
                         <div class="content-attributes">
+                            <div class="content-grid">
 
-                            <div class="content-weight content-attributes-general">
                                 <span class="att-weight att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressWeight progress"></div>
                                 </div>
-                                <span class="att-weight-result att-color"></span>
-                            </div>
+                                <span class="att-weight-result att-text att-color"></span>
 
-                            <div class="content-height content-attributes-general">
                                 <span class="att-height att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressHeight progress"></div>
                                 </div>
-                                <span class="att-height-result att-color"></span>
-                            </div>
+                                <span class="att-height-result att-text att-color"></span>
 
-                            <div class="content-health content-attributes-general">
                                 <span class="att-health att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressHealth progress"></div>
                                 </div>
-                                <span class="att-health-result att-color"></span>
-                            </div>
+                                <span class="att-health-result att-text att-color"></span>
 
-                            <div class="content-attack content-attributes-general">
                                 <span class="att-attack att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressAttack progress"></div>
                                 </div>
-                                <span class="att-attack-result att-color"></span>
-                            </div>
+                                <span class="att-attack-result att-text att-color"></span>
 
-                            <div class="content-specialAttack content-attributes-general">
                                 <span class="att-specialAttack att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressSpecialAttack progress"></div>
                                 </div>
-                                <span class="att-specialAttack-result att-color"></span>
-                            </div>
+                                <span class="att-specialAttack-result att-text att-color"></span>
 
-                            <div class="content-defense content-attributes-general">
                                 <span class="att-defense att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressDefense progress"></div>
                                 </div>
-                                <span class="att-defense-result att-color"></span>
-                            </div>
+                                <span class="att-defense-result att-text att-color"></span>
 
-                            <div class="content-specialDefense content-attributes-general">
                                 <span class="att-specialDefense att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressSpecialDefense progress"></div>
                                 </div>
-                                <span class="att-specialDefense-result att-color"></span>
-                            </div>
+                                <span class="att-specialDefense-result att-text att-color"></span>
 
-                            <div class="content-speed content-attributes-general">
                                 <span class="att-speed att-color"></span>
                                 <div class="progress-container">
                                     <div class="progressSpeed progress"></div>
                                 </div>
-                                <span class="att-speed-result att-color"></span>
+                                <span class="att-speed-result att-text att-color"></span>
+
                             </div>
                         </div>
                         <div class="content-imageId">

--- a/style.css
+++ b/style.css
@@ -170,11 +170,23 @@ input:focus {
     font-size: 30px;
 }
 
-.content-attributes-general {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+/* GRID ORGANIZATION */
+
+.content-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    grid-template-rows: repeat(8, 1fr);
+    gap: 33px;
+    
 }
+
+.att-text {
+    text-align: right;
+}
+
+
+/* ---------------------------- */
+
 
 .content-imageId {
     display: flex;
@@ -188,9 +200,6 @@ input:focus {
     color: #ffffff;
 }
 
-progress {
-    width: 22rem;
-}
 
 .att-color {
     white-space: nowrap;
@@ -202,6 +211,7 @@ progress {
     background-color: #A19E9E;
     position: relative;
     border-radius: 15px;
+    margin: 0 auto;
 }
 
 .progress {


### PR DESCRIPTION
Tirei as informações de dentro das divs, o que faziam com que as barras de progresso não estivessem centralizadas uma com as outras, e usei o grid para alinhar cada parte.